### PR TITLE
Simulate the RSL on the Romi

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -2,8 +2,10 @@
   "NTProvider": {
     "types": {
       "/FMSInfo": "FMSInfo",
+      "/LiveWindow/RSL": "Subsystem",
       "/LiveWindow/RomiDrivetrain": "Subsystem",
       "/LiveWindow/Ungrouped/DifferentialDrive[1]": "DifferentialDrive",
+      "/LiveWindow/Ungrouped/DigitalOutput[3]": "Digital Output",
       "/LiveWindow/Ungrouped/Scheduler": "Scheduler"
     }
   },

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -44,7 +44,7 @@ public final class Constants {
             m_port = port;
         }
 
-        public int getPort() {
+        public int get() {
             return m_port;
         }
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,10 +5,11 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.XboxController;
-import frc.robot.commands.DriveUsingXboxController;
-import frc.robot.subsystems.RomiDrivetrain;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
+import frc.robot.commands.DriveUsingXboxController;
+import frc.robot.subsystems.RSL;
+import frc.robot.subsystems.RomiDrivetrain;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -21,6 +22,8 @@ public class RobotContainer {
   private final XboxController m_xboxController = new XboxController(0);
 
   // The robot's subsystems and commands are defined here...
+  @SuppressWarnings("unused")
+  private final RSL m_rsl = new RSL();
   private final RomiDrivetrain m_romiDrivetrain = new RomiDrivetrain();
 
   private final Command m_autoCommand = new WaitCommand(1.0);

--- a/src/main/java/frc/robot/subsystems/RSL.java
+++ b/src/main/java/frc/robot/subsystems/RSL.java
@@ -1,0 +1,48 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.DigitalOutput;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.DigitalOutputPort;
+
+// A subsystem that simulates the Robot Signal Light using the Romi's
+// yellow LED indicator.
+public class RSL extends SubsystemBase {
+  public static final double kRslBlinkPeriod = 0.5;
+
+  private DigitalOutput m_yellowLED = new DigitalOutput(DigitalOutputPort.YellowLED.get());
+  private Timer m_timer = new Timer();
+  private Boolean wasDisabled = true;
+
+  /** Creates a new RSL. */
+  public RSL() {
+    m_yellowLED.set(true);
+  }
+
+  @Override
+  public void periodic() {
+    if (wasDisabled) {
+      if (DriverStation.isEnabled()) {
+        wasDisabled = false;
+        m_yellowLED.set(true);
+        m_timer.reset();
+        m_timer.start();
+      }
+    } else {
+      if (DriverStation.isDisabled()) {
+        wasDisabled = true;
+        m_yellowLED.set(true);
+        m_timer.stop();
+      }
+    }
+
+    if (m_timer.advanceIfElapsed(kRslBlinkPeriod)) {
+      m_yellowLED.set(!m_yellowLED.get());
+    }
+  }
+}


### PR DESCRIPTION
Adds a subsystem that simulates the [Robot Signal Light (RSL)](https://docs.wpilib.org/en/stable/docs/controls-overviews/control-system-hardware.html#robot-signal-light) using the Romi's yellow LED indicator.